### PR TITLE
add terraform workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,34 @@
+name: 'Terraform Validation Workflow'
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+jobs:
+  terraform_validation:
+    name: 'Terraform Validation'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@master
+      - name: 'Terraform Format'
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: 0.12.13
+          tf_actions_subcommand: 'fmt'
+      - name: 'Terraform Init'
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: 0.12.13
+          tf_actions_subcommand: 'init'
+      - name: 'Terraform Validate'
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: 0.12.13
+          tf_actions_subcommand: 'validate'
+        env:
+          # provider region is needed when running "terraform validate":
+          # https://github.com/hashicorp/terraform/issues/21408
+          AWS_DEFAULT_REGION: default


### PR DESCRIPTION
# Description

Adds a new Workflow for testing the terraform module using [GitHub Actions](https://github.com/features/actions):

- `terraform init`
- `terraform fmt`
- `terraform validate`

> `terraform validate` needs the environment variable `AWS_DEFAULT_REGION` because of [this issue](https://github.com/hashicorp/terraform/issues/21408).

[Terraform GitHub Actions](https://github.com/hashicorp/terraform-github-actions) is used for this workflow and triggers with `push` and `pull_request` on `master` branch.

Fixes #3 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

The workflow will start when a new commit or PR is created on the `master` branch.

- [x] Workflow started.
- [x] Code was checked out.
- [x] terraform fmt
- [x] terraform init
- [x] terraform validate

> This Pull Request will validate the GitHub Action.